### PR TITLE
Journalist can login

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ gem 'pg', '>= 0.18', '< 2.0'
 gem 'puma', '~> 4.1'
 gem 'bootsnap', '>= 1.4.2', require: false
 gem 'rack-cors', require: 'rack/cors'
+gem 'devise_token_auth'
 
 group :development, :test do
   gem 'pry-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -56,6 +56,7 @@ GEM
       minitest (~> 5.1)
       tzinfo (~> 1.1)
       zeitwerk (~> 2.2, >= 2.2.2)
+    bcrypt (3.1.16)
     bootsnap (1.5.1)
       msgpack (~> 1.0)
     builder (3.2.4)
@@ -68,6 +69,16 @@ GEM
       thor (>= 0.19.4, < 2.0)
       tins (~> 1.6)
     crass (1.0.6)
+    devise (4.7.3)
+      bcrypt (~> 3.0)
+      orm_adapter (~> 0.1)
+      railties (>= 4.1.0)
+      responders
+      warden (~> 1.2.3)
+    devise_token_auth (1.1.3)
+      bcrypt (~> 3.0)
+      devise (> 3.5.2, < 5)
+      rails (>= 4.2.0, < 6.1)
     diff-lcs (1.4.4)
     docile (1.3.2)
     erubi (1.10.0)
@@ -101,6 +112,7 @@ GEM
     nio4r (2.5.4)
     nokogiri (1.10.10)
       mini_portile2 (~> 2.4.0)
+    orm_adapter (0.5.0)
     pg (1.2.3)
     pry (0.13.1)
       coderay (~> 1.1)
@@ -144,6 +156,9 @@ GEM
     rb-fsevent (0.10.4)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
+    responders (3.0.1)
+      actionpack (>= 5.0)
+      railties (>= 5.0)
     rspec-core (3.10.0)
       rspec-support (~> 3.10.0)
     rspec-expectations (3.10.0)
@@ -188,6 +203,8 @@ GEM
       sync
     tzinfo (1.2.8)
       thread_safe (~> 0.1)
+    warden (1.2.9)
+      rack (>= 2.0.9)
     websocket-driver (0.7.3)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
@@ -199,6 +216,7 @@ PLATFORMS
 DEPENDENCIES
   bootsnap (>= 1.4.2)
   coveralls
+  devise_token_auth
   factory_bot_rails
   listen (~> 3.2)
   pg (>= 0.18, < 2.0)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,3 @@
 class ApplicationController < ActionController::API
+        include DeviseTokenAuth::Concerns::SetUserByToken
 end

--- a/app/models/admin.rb
+++ b/app/models/admin.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class Admin < ActiveRecord::Base
+  extend Devise::Models
+  devise :database_authenticatable, :registerable,
+         :recoverable, :rememberable, :trackable, :validatable
+  include DeviseTokenAuth::Concerns::User
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -1,3 +1,4 @@
+Resolving dependencies...
 require_relative "boot"
 
 require "rails"
@@ -35,6 +36,7 @@ module DreamTimeNewsApi
         resource "*",
           headers: :any,
           methods: %i[get post put delete],
+          expose: %w(access-token expiry token-type uid client),
           max_age: 0
       end
     end

--- a/config/application.rb
+++ b/config/application.rb
@@ -1,4 +1,3 @@
-Resolving dependencies...
 require_relative "boot"
 
 require "rails"

--- a/config/initializers/devise_token_auth.rb
+++ b/config/initializers/devise_token_auth.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+DeviseTokenAuth.setup do |config|
+  # By default the authorization headers will change after each request. The
+  # client is responsible for keeping track of the changing tokens. Change
+  # this to false to prevent the Authorization header from changing after
+  # each request.
+  # config.change_headers_on_each_request = true
+
+  # By default, users will need to re-authenticate after 2 weeks. This setting
+  # determines how long tokens will remain valid after they are issued.
+  # config.token_lifespan = 2.weeks
+
+  # Limiting the token_cost to just 4 in testing will increase the performance of
+  # your test suite dramatically. The possible cost value is within range from 4
+  # to 31. It is recommended to not use a value more than 10 in other environments.
+  config.token_cost = Rails.env.test? ? 4 : 10
+
+  # Sets the max number of concurrent devices per user, which is 10 by default.
+  # After this limit is reached, the oldest tokens will be removed.
+  # config.max_number_of_devices = 10
+
+  # Sometimes it's necessary to make several requests to the API at the same
+  # time. In this case, each request in the batch will need to share the same
+  # auth token. This setting determines how far apart the requests can be while
+  # still using the same auth token.
+  # config.batch_request_buffer_throttle = 5.seconds
+
+  # This route will be the prefix for all oauth2 redirect callbacks. For
+  # example, using the default '/omniauth', the github oauth2 provider will
+  # redirect successful authentications to '/omniauth/github/callback'
+  # config.omniauth_prefix = "/omniauth"
+
+  # By default sending current password is not needed for the password update.
+  # Uncomment to enforce current_password param to be checked before all
+  # attribute updates. Set it to :password if you want it to be checked only if
+  # password is updated.
+  # config.check_current_password_before_update = :attributes
+
+  # By default we will use callbacks for single omniauth.
+  # It depends on fields like email, provider and uid.
+  # config.default_callbacks = true
+
+  # Makes it possible to change the headers names
+  # config.headers_names = {:'access-token' => 'access-token',
+  #                        :'client' => 'client',
+  #                        :'expiry' => 'expiry',
+  #                        :'uid' => 'uid',
+  #                        :'token-type' => 'token-type' }
+
+  # By default, only Bearer Token authentication is implemented out of the box.
+  # If, however, you wish to integrate with legacy Devise authentication, you can
+  # do so by enabling this flag. NOTE: This feature is highly experimental!
+  # config.enable_standard_devise_support = false
+end

--- a/config/initializers/devise_token_auth.rb
+++ b/config/initializers/devise_token_auth.rb
@@ -5,11 +5,11 @@ DeviseTokenAuth.setup do |config|
   # client is responsible for keeping track of the changing tokens. Change
   # this to false to prevent the Authorization header from changing after
   # each request.
-  # config.change_headers_on_each_request = true
+  config.change_headers_on_each_request = false
 
   # By default, users will need to re-authenticate after 2 weeks. This setting
   # determines how long tokens will remain valid after they are issued.
-  # config.token_lifespan = 2.weeks
+  config.token_lifespan = 2.weeks
 
   # Limiting the token_cost to just 4 in testing will increase the performance of
   # your test suite dramatically. The possible cost value is within range from 4
@@ -24,7 +24,7 @@ DeviseTokenAuth.setup do |config|
   # time. In this case, each request in the batch will need to share the same
   # auth token. This setting determines how far apart the requests can be while
   # still using the same auth token.
-  # config.batch_request_buffer_throttle = 5.seconds
+  config.batch_request_buffer_throttle = 5.seconds
 
   # This route will be the prefix for all oauth2 redirect callbacks. For
   # example, using the default '/omniauth', the github oauth2 provider will

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,2 +1,3 @@
 Rails.application.routes.draw do
+  mount_devise_token_auth_for "Admin", at: "admin_auth"
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,8 @@
 Rails.application.routes.draw do
-  mount_devise_token_auth_for "Admin", at: "admin_auth"
+  mount_devise_token_auth_for "Admin", at: "api/v2/auth", skip: [:omniauth_callbacks]
+
+  namespace :api do
+    namespace :v2 do
+    end
+  end
 end

--- a/db/migrate/20201210103159_devise_token_auth_create_admins.rb
+++ b/db/migrate/20201210103159_devise_token_auth_create_admins.rb
@@ -1,0 +1,53 @@
+class DeviseTokenAuthCreateAdmins < ActiveRecord::Migration[6.0]
+  def change
+    
+    create_table(:admins) do |t|
+      ## Required
+      t.string :provider, :null => false, :default => "email"
+      t.string :uid, :null => false, :default => ""
+
+      ## Database authenticatable
+      t.string :encrypted_password, :null => false, :default => ""
+
+      ## Recoverable
+      t.string   :reset_password_token
+      t.datetime :reset_password_sent_at
+      t.boolean  :allow_password_change, :default => false
+
+      ## Rememberable
+      t.datetime :remember_created_at
+
+      ## Confirmable
+      t.string   :confirmation_token
+      t.datetime :confirmed_at
+      t.datetime :confirmation_sent_at
+      t.string   :unconfirmed_email # Only if using reconfirmable
+
+      ## Lockable
+      # t.integer  :failed_attempts, :default => 0, :null => false # Only if lock strategy is :failed_attempts
+      # t.string   :unlock_token # Only if unlock strategy is :email or :both
+      # t.datetime :locked_at
+
+      ## User Info
+      t.string :name
+      t.string :email
+
+      t.integer :sign_in_count, default: 0
+      t.datetime :current_sign_in_at
+      t.datetime :last_sign_in_at
+      t.string :current_sign_in_ip
+      t.string :last_sign_in_ip
+
+      ## Tokens
+      t.json :tokens
+
+      t.timestamps
+    end
+
+    add_index :admins, :email,                unique: true
+    add_index :admins, [:uid, :provider],     unique: true
+    add_index :admins, :reset_password_token, unique: true
+    add_index :admins, :confirmation_token,   unique: true
+    # add_index :admins, :unlock_token,       unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,37 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 0) do
+ActiveRecord::Schema.define(version: 2020_12_10_103159) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "admins", force: :cascade do |t|
+    t.string "provider", default: "email", null: false
+    t.string "uid", default: "", null: false
+    t.string "encrypted_password", default: "", null: false
+    t.string "reset_password_token"
+    t.datetime "reset_password_sent_at"
+    t.boolean "allow_password_change", default: false
+    t.datetime "remember_created_at"
+    t.string "confirmation_token"
+    t.datetime "confirmed_at"
+    t.datetime "confirmation_sent_at"
+    t.string "unconfirmed_email"
+    t.string "name"
+    t.string "email"
+    t.integer "sign_in_count", default: 0
+    t.datetime "current_sign_in_at"
+    t.datetime "last_sign_in_at"
+    t.string "current_sign_in_ip"
+    t.string "last_sign_in_ip"
+    t.json "tokens"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["confirmation_token"], name: "index_admins_on_confirmation_token", unique: true
+    t.index ["email"], name: "index_admins_on_email", unique: true
+    t.index ["reset_password_token"], name: "index_admins_on_reset_password_token", unique: true
+    t.index ["uid", "provider"], name: "index_admins_on_uid_and_provider", unique: true
+  end
 
 end

--- a/spec/factories/admins.rb
+++ b/spec/factories/admins.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :admin do
+    email { "admin@example.com" }
+    password { "password" }
+    password_confirmation { "password" }
+  end
+end

--- a/spec/factories/admins.rb
+++ b/spec/factories/admins.rb
@@ -1,6 +1,7 @@
 FactoryBot.define do
   factory :admin do
     email { "admin@example.com" }
+    name { "Bob" }
     password { "password" }
     password_confirmation { "password" }
   end

--- a/spec/models/admin_spec.rb
+++ b/spec/models/admin_spec.rb
@@ -1,0 +1,17 @@
+RSpec.describe Admin, type: :model do
+  it "is expected to have valid Factory" do
+    expect(create(:admin)).to be_valid
+  end
+
+  describe "Database table" do
+    it { is_expected.to have_db_column :encrypted_password }
+    it { is_expected.to have_db_column :email }
+    it { is_expected.to have_db_column :tokens }
+    it { is_expected.to have_db_column :name }
+  end
+
+  describe "Validations" do
+    it { is_expected.to validate_presence_of :email }
+    it { is_expected.to validate_confirmation_of :password }
+  end
+end

--- a/spec/requests/api/v2/login_spec.rb
+++ b/spec/requests/api/v2/login_spec.rb
@@ -1,0 +1,68 @@
+RSpec.describe 'POST /api/v2/auth/sign_in', type: :request do
+  let(:headers) { { HTTP_ACCEPT: 'application/json' } }
+  let(:admin) { create(:admin) }
+  let(:expected_response) do
+    {
+      'data' => {
+        'id' => admin.id, 'uid' => admin.email, 'email' => admin.email,
+        'provider' => 'email', 'name' => admin.name, 'allow_password_change' => false
+      }
+    }
+  end
+  describe 'with valid credentials' do
+    before do 
+      post '/api/v2/auth/sign_in',
+        params: {
+          email: admin.email,
+          password: admin.password
+        },
+        headers: headers
+    end
+
+    it 'returns 200 response status' do
+      expect(response).to have_http_status 200
+    end
+
+    it 'returns the expected response' do
+      expect(response_json).to eq expected_response
+    end
+  end
+
+  describe 'with invalid password' do
+    before do
+      post '/api/v2/auth/sign_in',
+        params: {
+          email: admin.email,
+          password: 'wrong_password'
+        },
+        headers: headers
+    end
+
+    it 'returns 401 response status' do
+      expect(response).to have_http_status 401
+    end
+
+    it 'returns error message' do
+      expect(response_json['errors']).to eq ['Invalid login credentials. Please try again.']
+    end
+  end
+
+  describe 'with invalid email' do
+    before do
+      post '/api/v2/auth/sign_in',
+        params: {
+          email: 'user@example.com',
+          password: admin.password
+        },
+        headers: headers
+    end
+
+    it 'returns 401 response status' do
+      expect(response).to have_http_status 401
+    end
+
+    it 'returns error message' do
+      expect(response_json['errors']).to eq ['Invalid login credentials. Please try again.']
+    end
+  end
+end


### PR DESCRIPTION
[Journalist can log in -API](https://www.pivotaltracker.com/story/show/176055862)
### User Story
```
As a journalist,
In order to write articles
I would like to be able to log in
```
## Changes proposed in this pull request:
* adding Admin model.
* modifying columns for admin db
* writing spec to test if admin can login. with model and Factory_Bot
* creating route for login to api/v2/auth.
* adding namespace api and adding namespace v2
* adding setting in devise_token_auth initializers
## What I have learned working on this feature:
* how to add a name for admins
## Packages/Gems added
* devise_token_auth