### PR TITLE
WIP: Journalist can restrict premium articles

### DIFF
--- a/app/controllers/api/articles_controller.rb
+++ b/app/controllers/api/articles_controller.rb
@@ -27,7 +27,7 @@ class Api::ArticlesController < ApplicationController
   private
 
   def article_params
-    params.require(:article).permit(:title, :sub_title, :content)
+    params.require(:article).permit(:title, :sub_title, :content, :premium)
   end
 
   def is_user_journalist?

--- a/app/serializers/articles_show_serializer.rb
+++ b/app/serializers/articles_show_serializer.rb
@@ -1,5 +1,5 @@
 class ArticlesShowSerializer < ActiveModel::Serializer
-  attributes :id, :title, :sub_title, :content, :image, :created_at, :updated_at, :author
+  attributes :id, :title, :sub_title, :content, :image, :created_at, :updated_at, :author, :premium
 
   def created_at
     object.created_at.strftime('%F')

--- a/db/migrate/20210116213242_add_premium_to_articles.rb
+++ b/db/migrate/20210116213242_add_premium_to_articles.rb
@@ -1,0 +1,5 @@
+class AddPremiumToArticles < ActiveRecord::Migration[6.0]
+  def change
+    add_column :articles, :premium, :boolean, default: true
+  end
+end

--- a/db/migrate/20210116213242_add_premium_to_articles.rb
+++ b/db/migrate/20210116213242_add_premium_to_articles.rb
@@ -1,5 +1,5 @@
 class AddPremiumToArticles < ActiveRecord::Migration[6.0]
   def change
-    add_column :articles, :premium, :boolean, default: true
+    add_column :articles, :premium, :boolean default: false
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_01_09_140428) do
+ActiveRecord::Schema.define(version: 2021_01_16_213242) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -43,6 +43,7 @@ ActiveRecord::Schema.define(version: 2021_01_09_140428) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.integer "author_id", null: false
+    t.boolean "premium", default: true
   end
 
   create_table "users", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -43,7 +43,7 @@ ActiveRecord::Schema.define(version: 2021_01_16_213242) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.integer "author_id", null: false
-    t.boolean "premium", default: true
+    t.boolean "premium", default: false
   end
 
   create_table "users", force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -7,4 +7,3 @@
 #   Character.create(name: 'Luke', movie: movies.first)
 
 User.create(email: 'journalist@mail.com', password: 'password', role: 'journalist')
-5.times {Article.create(title: 'Covid', sub_title: 'Covid 19', content: 'Covid coming', author_id: 1)}

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -3,6 +3,8 @@ RSpec.describe Article, type: :model do
     it { is_expected.to have_db_column :title }
     it { is_expected.to have_db_column :sub_title }
     it { is_expected.to have_db_column :content}
+    it { is_expected.to have_db_column :premium}
+
   end
   describe 'Validations' do
     it { is_expected.to validate_presence_of :title }

--- a/spec/requests/api/visitor_can_read_specific_article_spec.rb
+++ b/spec/requests/api/visitor_can_read_specific_article_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe 'GET/api/articles', type: :request do
     it 'is expected to return content of the article' do
       expect(response_json['article']['content']).to eq 'MyText'
     end
-    it 'is expected to return content of the article' do
+    it 'is expected to return author of the article' do
       expect(response_json['article']['author']).to eq 'user@example.com'
     end
   end


### PR DESCRIPTION
[Journalist can restrict premium articles for non-subscribers- API](https://www.pivotaltracker.com/story/show/176358074)

### User Story
```
As a site owner, 
In order to get more registered users,
I would like to restrict certain content and offer special premium content to registered users only

```
## Changes proposed in this pull request:

*  Add premium attribute to articles in database and both index and show serializer files 
*  Adds premium column to articles table
*  Write tests to check if journalist can create premium articles so then he/she can restrict that from non-subscribers

## What we have learned working on this feature:

*  How to generate a new migration to database
*  To write tests to check if journalist can write premium articles

